### PR TITLE
add observerFor and observerPromiseFor

### DIFF
--- a/addon/-private/computed/observed/observer.js
+++ b/addon/-private/computed/observed/observer.js
@@ -5,8 +5,3 @@ export const observerFor = (owner, key) => {
   let internal = cacheFor(owner, key);
   return internal && internal.observer;
 }
-
-export const observerPromiseFor = (owner, key) => {
-  let observer = observerFor(owner, key);
-  return observer && get(observer, 'promise');
-}

--- a/addon/-private/computed/observed/observer.js
+++ b/addon/-private/computed/observed/observer.js
@@ -1,0 +1,12 @@
+import { get } from '@ember/object';
+import { cacheFor } from '../../util/destroyable';
+
+export const observerFor = (owner, key) => {
+  let internal = cacheFor(owner, key);
+  return internal && internal.observer;
+}
+
+export const observerPromiseFor = (owner, key) => {
+  let observer = observerFor(owner, key);
+  return observer && get(observer, 'promise');
+}

--- a/addon/-private/computed/observed/observer.js
+++ b/addon/-private/computed/observed/observer.js
@@ -1,4 +1,3 @@
-import { get } from '@ember/object';
 import { cacheFor } from '../../util/destroyable';
 
 export const observerFor = (owner, key) => {

--- a/addon/experimental/computed.js
+++ b/addon/experimental/computed.js
@@ -1,8 +1,7 @@
 import observed from '../-private/computed/observed/property';
-import { observerFor, observerPromiseFor } from '../-private/computed/observed/observer';
+import { observerFor } from '../-private/computed/observed/observer';
 
 export {
   observed,
-  observerFor,
-  observerPromiseFor
+  observerFor
 }

--- a/addon/experimental/computed.js
+++ b/addon/experimental/computed.js
@@ -1,5 +1,8 @@
 import observed from '../-private/computed/observed/property';
+import { observerFor, observerPromiseFor } from '../-private/computed/observed/observer';
 
 export {
-  observed
+  observed,
+  observerFor,
+  observerPromiseFor
 }

--- a/tests/unit/computed-observed-test.js
+++ b/tests/unit/computed-observed-test.js
@@ -1,6 +1,6 @@
 import EmberObject from '@ember/object';
 import { module, test, setupStoreTest } from '../helpers/setup';
-import { observed, observerFor, observerPromiseFor } from 'ember-cli-zuglet/experimental/computed';
+import { observed, observerFor } from 'ember-cli-zuglet/experimental/computed';
 import { getOwner } from '@ember/application';
 import { assign } from '@ember/polyfills';
 import { run } from '@ember/runloop';
@@ -86,12 +86,6 @@ module('computed-observed', function(hooks) {
     let subject = this.subject();
     let model = this.model({ doc: observed() }, { doc: subject });
     assert.equal(observerFor(model, 'doc').isObserver, true);
-  });
-
-  test('observer promise for returns promise', async function(assert) {
-    let subject = this.subject();
-    let model = this.model({ doc: observed() }, { doc: subject });
-    assert.equal(observerPromiseFor(model, 'doc').isPromise, true);
   });
 
 });

--- a/tests/unit/computed-observed-test.js
+++ b/tests/unit/computed-observed-test.js
@@ -1,6 +1,6 @@
 import EmberObject from '@ember/object';
 import { module, test, setupStoreTest } from '../helpers/setup';
-import { observed } from 'ember-cli-zuglet/experimental/computed';
+import { observed, observerFor, observerPromiseFor } from 'ember-cli-zuglet/experimental/computed';
 import { getOwner } from '@ember/application';
 import { assign } from '@ember/polyfills';
 import { run } from '@ember/runloop';
@@ -16,6 +16,10 @@ module('computed-observed', function(hooks) {
       observe() {
         this.isObserved = true;
         return {
+          isObserver: true,
+          promise: {
+            isPromise: true
+          },
           cancel: () => this.isObserved = false
         };
       }
@@ -66,6 +70,28 @@ module('computed-observed', function(hooks) {
     assert.equal(subject.isObserved, true);
     run(() => model.destroy());
     assert.equal(subject.isObserved, false);
+  });
+
+  test('observer for returns undefined for missing key', async function(assert) {
+    let model = this.model({ doc: observed() }, { });
+    assert.equal(observerFor(model, 'foo'), undefined);
+  });
+
+  test('observer for returns undefined for undefined value', async function(assert) {
+    let model = this.model({ doc: observed() }, { });
+    assert.equal(observerFor(model, 'doc'), undefined);
+  });
+
+  test('observer for returns observer', async function(assert) {
+    let subject = this.subject();
+    let model = this.model({ doc: observed() }, { doc: subject });
+    assert.equal(observerFor(model, 'doc').isObserver, true);
+  });
+
+  test('observer promise for returns promise', async function(assert) {
+    let subject = this.subject();
+    let model = this.model({ doc: observed() }, { doc: subject });
+    assert.equal(observerPromiseFor(model, 'doc').isPromise, true);
   });
 
 });


### PR DESCRIPTION
``` javascript
import { 
  observed, 
  observerFor, 
  observerPromiseFor
} from 'ember-cli-zuglet/experimental/computed';

export default EmberObject.extend({

  doc: observed(),

});

observerFor(instance, 'doc') // => observer
observerPromiseFor(instance, 'doc') // => observer.promise
```