### PR TITLE
Storage api updates

### DIFF
--- a/addon/-private/storage/reference/reference.js
+++ b/addon/-private/storage/reference/reference.js
@@ -50,4 +50,8 @@ export default EmberObject.extend(ModelMixin, RefPropertiesMixin, {
 
   ref: invokeReturningModel('child'),
 
+  toStringExtension() {
+    return this.get('fullPath');
+  }
+
 });

--- a/addon/-private/storage/reference/reference.js
+++ b/addon/-private/storage/reference/reference.js
@@ -45,6 +45,9 @@ export default EmberObject.extend(ModelMixin, RefPropertiesMixin, {
     return this._internal.put(opts).model(true);
   },
 
-  child: invokeReturningModel('child')
+  // will be deprecated in favor of `ref`
+  child: invokeReturningModel('child'),
+
+  ref: invokeReturningModel('child'),
 
 });

--- a/addon/-private/storage/task/task.js
+++ b/addon/-private/storage/task/task.js
@@ -3,6 +3,7 @@ import { readOnly } from '@ember/object/computed';
 import Mixin from '@ember/object/mixin';
 import ModelMixin from '../../internal/model-mixin';
 import serialized from '../../util/serialized';
+import createThenable from '../../util/thenable';
 
 const snapshot = [
   'bytesTransferred',
@@ -34,7 +35,9 @@ const SnapshotPropertiesMixin = Mixin.create(snapshot.reduce((hash, key) => {
   return hash;
 }, {}));
 
-export default EmberObject.extend(ModelMixin, TaskPropertiesMixin, SnapshotPropertiesMixin, {
+const ThenableMixin = createThenable('promise');
+
+export default EmberObject.extend(ModelMixin, TaskPropertiesMixin, SnapshotPropertiesMixin, ThenableMixin, {
 
   ref: computed(function() {
     return this._internal.ref.model(true);
@@ -43,7 +46,7 @@ export default EmberObject.extend(ModelMixin, TaskPropertiesMixin, SnapshotPrope
   serialized: serialized([ ...task, ...snapshot ]),
 
   promise: computed('_internal.promise', function() {
-    return this.get('_internal.promise').then(() => this);
+    return this.get('_internal.promise').then(() => undefined);
   }).readOnly(),
 
   toStringExtension() {

--- a/addon/-private/storage/task/task.js
+++ b/addon/-private/storage/task/task.js
@@ -46,4 +46,8 @@ export default EmberObject.extend(ModelMixin, TaskPropertiesMixin, SnapshotPrope
     return this.get('_internal.promise').then(() => this);
   }).readOnly(),
 
+  toStringExtension() {
+    return this.get('ref.fullPath');
+  }
+
 });

--- a/addon/-private/util/thenable.js
+++ b/addon/-private/util/thenable.js
@@ -5,7 +5,7 @@ export default arg => {
   let lookup;
 
   if(typeof arg === 'string') {
-    lookup = owner => owner[arg];
+    lookup = owner => owner.get(arg);
   } else {
     lookup = arg;
   }

--- a/addon/-private/util/thenable.js
+++ b/addon/-private/util/thenable.js
@@ -1,0 +1,24 @@
+import Mixin from '@ember/object/mixin';
+
+export default arg => {
+
+  let lookup;
+
+  if(typeof arg === 'string') {
+    lookup = owner => owner[arg];
+  } else {
+    lookup = arg;
+  }
+
+  const wrap = target => function(...args) {
+    let promise = lookup.call(this, this);
+    let fn = promise[target];
+    return fn.call(promise, ...args);
+  }
+
+  return Mixin.create({
+    then:    wrap('then'),
+    catch:   wrap('catch'),
+    finally: wrap('finally')
+  });
+};

--- a/tests/unit/storage-test.js
+++ b/tests/unit/storage-test.js
@@ -491,6 +491,12 @@ module('storage', function(hooks) {
     assert.equal(image.get('fullPath'), 'images/image');
   });
 
+  test('ref ref', async function(assert) {
+    let images = this.storage.ref('images');
+    let image = images.ref('image');
+    assert.equal(image.get('fullPath'), 'images/image');
+  });
+
   test('ref parent', async function(assert) {
     let image = this.storage.ref('images/image');
     let images = image.get('parent');

--- a/tests/unit/storage-test.js
+++ b/tests/unit/storage-test.js
@@ -131,6 +131,38 @@ module('storage', function(hooks) {
     await promise;
   });
 
+  test('put blob with thenable', async function(assert) {
+    await this.signIn();
+
+    let ref = this.storage.ref({ path: 'hello' });
+
+    let task = ref.put({
+      type: 'data',
+      data: new Blob([ 'hello world as a blob' ]),
+      metadata: {
+        contentType: 'text/plain',
+        customMetadata: { ok: true }
+      }
+    });
+
+    assert.ok(typeof task.then === 'function');
+    assert.ok(typeof task.catch === 'function');
+    assert.ok(typeof task.finally === 'function');
+
+    await task;
+
+    assert.deepEqual(task.get('serialized'), {
+      "bytesTransferred": 21,
+      "error": null,
+      "isCompleted": true,
+      "isError": false,
+      "isRunning": false,
+      "percent": 100,
+      "totalBytes": 21,
+      "type": "data"
+    });
+  });
+
   test('settle', async function(assert) {
     await this.signIn();
     let task = this.put();
@@ -162,7 +194,7 @@ module('storage', function(hooks) {
     assert.ok(tasks.includes(task));
 
     let r = await task.get('promise');
-    assert.ok(r === task);
+    assert.ok(r === undefined);
 
     assert.ok(tasks.get('length') === 0);
 


### PR DESCRIPTION
Fixed #52 

* `task` is now thenable
* toStringExtension for task and ref
* `ref.ref('child')` (instead of `ref.child('child')`)