### PR TITLE
don't replace primitive data internal if content equals

### DIFF
--- a/addon/-private/data/primitive/serializer.js
+++ b/addon/-private/data/primitive/serializer.js
@@ -20,9 +20,14 @@ export default Serializer.extend({
   },
 
   deserialize(internal, value) {
-    if(internal.content !== value) {
-      internal.content = value;
+    if(internal.content === value) {
+      return {
+        replace: false,
+        internal
+      };
     }
+
+    internal.content = value;
 
     return {
       replace: true,


### PR DESCRIPTION
so that property change is not triggered