### PR TITLE
clear array mapper content on destroy

### DIFF
--- a/addon/-private/lifecycle/models/array-mapper.js
+++ b/addon/-private/lifecycle/models/array-mapper.js
@@ -60,7 +60,9 @@ export default class ArrayMapper {
   }
 
   destroy() {
-    this.content.map(holder => holder.destroy());
+    let { content } = this;
+    content.map(holder => holder.destroy());
+    content.clear();
   }
 
 }


### PR DESCRIPTION
fixes Uncaught Error: Assertion Failed: Cannot update watchers for `position` on `<bain@model:sketch/stage/node/rect::ember534:sketches/wip/nodes/QcgaEURW1afxEocCEsCR>` after it has been destroyed.