### PR TITLE
Touch query array proxy content before onChanges, onReplace

### DIFF
--- a/addon/-private/lifecycle/util/object-observer.js
+++ b/addon/-private/lifecycle/util/object-observer.js
@@ -12,6 +12,7 @@ const withKeys = (keys, cb) => {
 
 export const startObservingObject = (object, keys, target, method) => {
   if(!object) {
+    console.warn('zuglet', 'startObservingObject without an object', keys, target, method);
     return;
   }
   withKeys(keys, key => addObserver(object, key, target, method));
@@ -19,6 +20,7 @@ export const startObservingObject = (object, keys, target, method) => {
 
 export const stopObservingObject = (object, keys, target, method) => {
   if(!object) {
+    console.warn('zuglet', 'stopObservingObject without an object', keys, target, method);
     return;
   }
   withKeys(keys, key => removeObserver(object, key, target, method));

--- a/addon/-private/query/array/internal.js
+++ b/addon/-private/query/array/internal.js
@@ -60,6 +60,7 @@ export default QueryInternal.extend({
 
   onChanges(snapshot) {
     this.proxyContentWillChange();
+
     snapshot.docChanges({ includeMetadataChanges: true }).map(change => this.onChange(change));
   },
 

--- a/addon/-private/query/array/internal.js
+++ b/addon/-private/query/array/internal.js
@@ -16,6 +16,16 @@ export default QueryInternal.extend({
     return this.store.factoryFor('zuglet:query/array/content').create({ content });
   }).readOnly(),
 
+  proxyContentWillChange() {
+    // When objects are removed from content and before that proxy hasn't been touched,
+    // in proxy array observer (`array.addArrayObserver`) callbacks undefined objects are returned
+    //
+    // This is due to the fact array proxy is using `arrangedContent` in weird way.
+    // That needs a better solution.
+    //
+    this.get('proxy').slice();
+  },
+
   createModel() {
     return this.store.factoryFor('zuglet:query/array').create({ _internal: this });
   },
@@ -26,7 +36,6 @@ export default QueryInternal.extend({
     let { type, oldIndex, newIndex, doc: snapshot } = change;
 
     let path = snapshot.ref.path;
-
     let content = this.get('content');
 
     if(type === 'added') {
@@ -50,10 +59,13 @@ export default QueryInternal.extend({
   },
 
   onChanges(snapshot) {
+    this.proxyContentWillChange();
     snapshot.docChanges({ includeMetadataChanges: true }).map(change => this.onChange(change));
   },
 
   onReplace(snapshot) {
+    this.proxyContentWillChange();
+
     let content = this.get('content');
     let documents = A(snapshot.docs.map(doc => {
       let document = content.findBy('ref.path', doc.ref.path);


### PR DESCRIPTION
This is temporary workaround for the issue with array proxy observers not getting objects in willChange, didChange callbacks. If proxy hasn't been touched, slice(start, len) returns array of undefined