### PR TITLE
doc.save({ type: 'set', optional: true })

### DIFF
--- a/addon/-private/document/internal.js
+++ b/addon/-private/document/internal.js
@@ -197,7 +197,12 @@ export default Internal.extend({
   },
 
   _normalizeSaveOptions(opts={}) {
-    return assign({ type: 'set', merge: false, optional: false }, opts);
+    return assign({ type: 'set', merge: false, optional: false, dirty: false }, opts);
+  },
+
+  _shouldSkipSave(opts) {
+    let { isDirty, isNew } = this.getProperties('isDirty', 'isNew');
+    return opts.optional && opts.type === 'set' && !isDirty && !isNew;
   },
 
   save(opts) {
@@ -205,12 +210,20 @@ export default Internal.extend({
     return this.get('queue').schedule({
       name: 'document/save',
       invoke: () => {
+        if(this._shouldSkipSave(opts)) {
+          return;
+        }
         let ref = this.get('ref.ref');
         let data = this.get('data').serialize('raw');
         this.willSave(data, opts);
         return this._save(ref, data, opts);
       },
-      didResolve: raw => this.didSave(raw),
+      didResolve: raw => {
+        if(!raw) {
+          return this;
+        }
+        return this.didSave(raw);
+      },
       didReject: err => this.saveDidFail(err, opts)
     });
   },

--- a/addon/-private/document/internal.js
+++ b/addon/-private/document/internal.js
@@ -197,7 +197,7 @@ export default Internal.extend({
   },
 
   _normalizeSaveOptions(opts={}) {
-    return assign({ type: 'set', merge: false, optional: false, dirty: false }, opts);
+    return assign({ type: 'set', merge: false, optional: false }, opts);
   },
 
   _shouldSkipSave(opts) {

--- a/docs/api/store/document.md
+++ b/docs/api/store/document.md
@@ -131,7 +131,20 @@ Saves document in Firestore database.
 * `merge` → `Boolean` (defaults to `false`), used only if `type` is `set`
 * `optional` → `Boolean` (defaults to `false`), used only if `type` is `update`
 
-If no options are provided, defaults (`{ type: 'set', merge: false }`) always overwrites the whole document. To change this behavior, use `{ merge: true }` to do a server-side merge of existing document properties with added ones.
+If no options are provided, defaults (`{ type: 'set', merge: false, optional: false }`) always overwrites the whole document. To change this behavior, use `{ merge: true }` to do a server-side merge of existing document properties with added ones.
+
+By default documents are saved even if they are not dirty. To skip saving non-new, non-dirty documents, pass `{optional: true }`.
+
+**Save dirty document:**
+
+``` javascript
+let doc = await store.doc('duck/yellow').new();
+doc.set('data.address', { street: 'Duck Street' });
+await doc.save({ optional: true });
+// → This save will save document as it was new
+await doc.save({ optional: true });
+// → This save will skip saving document as it was not dirty and not new
+```
 
 **Save document by overwriting all the properties:**
 

--- a/tests/unit/document-test.js
+++ b/tests/unit/document-test.js
@@ -139,6 +139,38 @@ module('document', function(hooks) {
     });
   });
 
+  test('save pristine document', async function(assert) {
+    let ref = this.store.doc('ducks/yellow');
+    let doc = ref.new({ name: 'yellow', feathers: 'cute' });
+
+    assert.equal(doc.isNew, true);
+    assert.equal(doc.isDirty, false);
+
+    await doc.save({ optional: true });
+
+    assert.equal(doc.isNew, false);
+    assert.equal(doc.isDirty, false);
+
+    let loaded;
+
+    loaded = await this.store.doc('ducks/yellow').load();
+    assert.deepEqual(loaded.data.serialized, {
+      name: 'yellow',
+      feathers: 'cute'
+    });
+
+    loaded.set('data.feathers', 'cutest');
+    await loaded.save();
+
+    await doc.save({ optional: true });
+
+    loaded = await this.store.doc('ducks/yellow').load();
+    assert.deepEqual(loaded.data.serialized, {
+      name: 'yellow',
+      feathers: 'cutest'
+    });
+  });
+
   test('delete document', async function(assert) {
     let doc = this.store.doc('ducks/yellow').new({ name: 'yellow', feathers: 'cute' });
     await doc.save();


### PR DESCRIPTION
skip save if not new or dirty